### PR TITLE
Pr/4710/1

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -160,9 +160,9 @@ module LogStash::Config::Mixin
       default = Regexp.last_match(:default)
 
       replacement = ENV.fetch(name, default)
-      #if replacement.nil?
-        #raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Environment variable `#{name}` is not set and there is no default value given."
-      #end
+      if replacement.nil?
+        raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Environment variable `#{name}` is not set and there is no default value given."
+      end
       @logger.info? && @logger.info("Replacing config environment variable '#{placeholder}' with `#{replacement}`")
       replacement
     end

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -163,7 +163,7 @@ module LogStash::Config::Mixin
       if replacement.nil?
         raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Environment variable `#{name}` is not set and there is no default value given."
       end
-      @logger.info? && @logger.info("Replacing config environment variable '#{placeholder}' with `#{replacement}`")
+      @logger.info? && @logger.info("Evaluating environment variable placeholder", :placeholder => placeholder, :replacement => replacement)
       replacement
     end
   end # def replace_env_placeholders

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -38,8 +38,7 @@ module LogStash::Config::Mixin
   PLUGIN_VERSION_1_0_0 = LogStash::Util::PluginVersion.new(1, 0, 0)
   PLUGIN_VERSION_0_9_0 = LogStash::Util::PluginVersion.new(0, 9, 0)
   
-  ENV_PLACEHOLDER_REGEX = Regexp.new(/\$\w+|\$\{\w+(\:[^}]*)?\}/)
-
+  ENV_PLACEHOLDER_REGEX = /\$(?<name>\w+)|\$\{(?<name>\w+)(\:(?<default>[^}]*))?\}/
 
   # This method is called when someone does 'include LogStash::Config'
   def self.included(base)
@@ -149,37 +148,24 @@ module LogStash::Config::Mixin
   # Replace all environment variable references in 'value' param by environment variable value and return updated value
   # Process following patterns : $VAR, ${VAR}, ${VAR:defaultValue}
   def replace_env_placeholders(value)
-    if (value.is_a?(String))
-      while value =~ ENV_PLACEHOLDER_REGEX
-        valueParts = value.partition(ENV_PLACEHOLDER_REGEX)
-        placeHolder = valueParts[1]
-        if placeHolder.start_with?("${")
-          envVarName = placeHolder.slice(2..placeHolder.length - 2)
-        else
-          envVarName = placeHolder.slice(1..placeHolder.length - 1)
-        end
-        if envVarName.include?(':')
-          placeHolderParts = envVarName.split(':')
-          envVarName = placeHolderParts[0]
-          defaultValue = placeHolderParts[1] || ""
-        else
-          defaultValue = ""
-        end
-        
-        envVarValue = ENV[envVarName]
-        if envVarValue.nil? 
-          envVarValue = defaultValue
-          if defaultValue.empty?
-            @logger.warn("In plugin '#{self.class.config_name}', " +
-                         "referenced environment variable '#{envVarName}' does not exist. " +
-                         "This reference has been replaced by empty string.")
-          end
-        end
-        value = valueParts[0] << envVarValue << valueParts[2]
-        @logger.info("Replacing config environment variable '#{placeHolder}' with #{envVarValue}")
-      end
+    return value unless value.is_a?(String)
+    #raise ArgumentError, "Cannot replace ENV placeholders on non-strings. Got #{value.class}" if !value.is_a?(String)
+
+    value.gsub(ENV_PLACEHOLDER_REGEX) do |placeholder|
+      # Note: Ruby docs claim[1] Regexp.last_match is thread-local and scoped to
+      # the call, so this should be thread-safe.
+      #
+      # [1] http://ruby-doc.org/core-2.1.1/Regexp.html#method-c-last_match
+      name = Regexp.last_match(:name)
+      default = Regexp.last_match(:default)
+
+      replacement = ENV.fetch(name, default)
+      #if replacement.nil?
+        #raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Environment variable `#{name}` is not set and there is no default value given."
+      #end
+      @logger.info? && @logger.info("Replacing config environment variable '#{placeholder}' with `#{replacement}`")
+      replacement
     end
-    return value
   end # def replace_env_placeholders
 
   module DSL

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -152,7 +152,7 @@ describe LogStash::Config::Mixin do
     end
   end
 
-  context "environment variable injection" do
+  context "environment variable evaluation" do
     let(:plugin_class) do
       Class.new(LogStash::Filters::Base)  do
         config_name "one_plugin"
@@ -164,36 +164,74 @@ describe LogStash::Config::Mixin do
       end
     end
     
-    ENV["MIXIN_SPEC_ENV_VAR"] = "123"
-
-    subject {
-      plugin_class.new({
-        "oneString" => "${notExistingVar}",
-        "oneBoolean" => "${notExistingVar:true}",
-        "oneNumber" => "${MIXIN_SPEC_ENV_VAR}",
-        "oneArray" => [ "first array value", "$MIXIN_SPEC_ENV_VAR" ],
-        "oneHash" => { "key" => "$MIXIN_SPEC_ENV_VAR" }
-      })
-    }
-     
-    it "should have oneString param as empty string (env var not found)" do
-      expect(subject.oneString).to(be == "")
+    before do
+      ENV["MIXIN_SPEC_ENV_VAR"] = "123"
     end
 
-    it "should have oneNumber param with environment variable injected" do
-      expect(subject.oneNumber).to(be == 123)
+    after do
+      ENV.delete("MIXIN_SPEC_ENV_VAR")
     end
 
-    it "should have oneBoolean param with default value" do
-      expect(subject.oneBoolean).to(be == true)
+    context "when an environment variable is not set" do
+      context "and no default is given" do
+        before do
+          # Canary. Just in case somehow this is set.
+          expect(ENV["NoSuchVariable"]).to be_nil
+        end
+
+        it "should raise a configuration error" do
+          expect do
+            plugin_class.new("example" => "${NoSuchVariable}")
+          end.to raise_error(LogStash::ConfigurationError)
+        end
+      end
+
+      context "and a default is given" do
+        subject do
+          plugin_class.new(
+            "oneString" => "${notExistingVar:foo}",
+            "oneBoolean" => "${notExistingVar:true}",
+            "oneArray" => [ "first array value", "${notExistingVar:foo}" ],
+            "oneHash" => { "key" => "${notExistingVar:foo}" }
+          )
+        end
+
+        it "should use the default" do
+          expect(subject.oneString).to(be == "foo")
+          expect(subject.oneBoolean).to be_truthy
+          expect(subject.oneArray).to(be == ["first array value", "foo"])
+          expect(subject.oneHash).to(be == { "key" => "foo" })
+        end
+      end
     end
 
-    it "should have oneArray param with environment variable injected" do
-      expect(subject.oneArray).to include("123")
-    end
+    context "when an environment variable is set" do
+      before do
+        ENV["FunString"] = "fancy"
+        ENV["FunBool"] = "true"
+      end
 
-    it "should have oneHash param with environment variable injected" do
-      expect(subject.oneHash["key"]).to(be == "123")
+      after do
+        ENV.delete("FunString")
+        ENV.delete("FunBool")
+      end
+
+      subject do
+        plugin_class.new(
+          "oneString" => "${FunString:foo}",
+          "oneBoolean" => "${FunBool:false}",
+          "oneArray" => [ "first array value", "${FunString:foo}" ],
+          "oneHash" => { "key" => "${FunString:foo}" }
+        )
+      end
+
+      it "should use the value in the variable" do
+        expect(subject.oneString).to(be == "fancy")
+        expect(subject.oneBoolean).to(be_truthy)
+        expect(subject.oneArray).to(be == [ "first array value", "fancy" ])
+        expect(subject.oneHash).to(be == { "key" => "fancy" })
+      end
+
     end
   end
 


### PR DESCRIPTION
This is an implementation of some of my comments for your pr https://github.com/elastic/logstash/pull/4710

I've implemented:
- `${FOO}` will raise a configuration error if FOO is not present in the environment variables list. (`${FOO:default}` is allowed, though)
- Small changes to the tests based on the new behavior (config error if no env var)
